### PR TITLE
Fix for React@0.15.1(replace cloneAndReplaceProps with cloneElement).

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel": "5.8.23",
-    "babel-eslint": "4.1.3",
+    "babel-eslint": "4.1.7",
     "babel-tape-runner": "1.2.0",
     "baconjs": "0.7.80",
     "bluebird": "3.0.5",

--- a/src/combineVDOM.js
+++ b/src/combineVDOM.js
@@ -1,4 +1,4 @@
-import {cloneAndReplaceProps, isValidElement} from "react/lib/ReactElement"
+import {cloneElement, isValidElement} from "react/lib/ReactElement"
 import {contains, isEmpty, isArray, zip, find} from "./util"
 import Combinator from "./Combinator"
 
@@ -65,7 +65,7 @@ export default ({constant, combineAsArray, isObservable, map}) => {
           }
         }
       }
-      return cloneAndReplaceProps(el, newProps)
+      return cloneElement(el, newProps)
     }
   }
 }

--- a/test/bmiTest.js
+++ b/test/bmiTest.js
@@ -1,4 +1,4 @@
-import {testExample, await} from "./helpers"
+import {testExample, awaitMs} from "./helpers"
 
 
 testExample("01-bmi", (t, browser) => {
@@ -6,7 +6,7 @@ testExample("01-bmi", (t, browser) => {
   browser.assert.input("input.Height", 180)
   browser.assert.text(".bmi", "25")
   browser.fill("input.Height", 200)
-  return await(50).then(() => {
+  return awaitMs(50).then(() => {
     t.comment("test changed values")
     browser.assert.input("input.Height", 200)
     browser.assert.text(".bmi", "20")

--- a/test/editorsTest.js
+++ b/test/editorsTest.js
@@ -1,4 +1,4 @@
-import {testExample, await} from "./helpers"
+import {testExample, awaitMs} from "./helpers"
 
 
 testExample("03-editors", (t, browser) => {
@@ -9,7 +9,7 @@ testExample("03-editors", (t, browser) => {
   browser.click("#add")
   browser.click("#add")
 
-  return await(50)
+  return awaitMs(50)
     .then(() => {
       t.comment("test that counters were created")
       browser.assert.text("h1", "Editors 2")

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -18,7 +18,7 @@ export function testExample(example, testCase) {
       const browser = polyfillBrowser(new Browser())
       Promise.resolve(browser.visit("file://" + getExampleDir(example) + "/index.html"))
         .then(() => browser.assert.success())
-        .then(() => await(500))
+        .then(() => awaitMs(500))
         .then(() => testCase(t, browser))
         .finally(() => t.end())
         .done()
@@ -26,7 +26,7 @@ export function testExample(example, testCase) {
   })
 }
 
-export function await(ms) {
+export function awaitMs(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 


### PR DESCRIPTION
Replace ReactElement.cloneAndReplaceProps with ReactElement.cloneElement,
because ReactElement.cloneAndReplaceProps was removed in https://github.com/facebook/react/pull/6082.
